### PR TITLE
Limited the number of children processes created

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "lpad": "~0.1.0",
-    "colors": "~0.6.2"
+    "colors": "~0.6.2",
+    "async": "~0.2.9"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,13 @@ Default value: `'npm'`
 
 The location of the `npm` executable. Defaults to `'npm'` as it should be available in the `$PATH` environment variable.
 
+#### options.limit
+Type: `Number`  
+Default value: Number of CPU cores (`require('os').cpus().length`) with a minimum of 2
+
+Limit how many sub-grunt projects are launched concurrently.
+
+
 ### Usage Examples
 
 ```js

--- a/tasks/subgrunt.js
+++ b/tasks/subgrunt.js
@@ -1,5 +1,6 @@
 'use strict';
-var lpad = require('lpad');
+var lpad = require('lpad'),
+    async = require('async');
 require('colors');
 
 module.exports = function (grunt) {
@@ -76,7 +77,8 @@ module.exports = function (grunt) {
         var options = this.options({
             npmInstall: true,
             npmClean: false,
-            npmPath: 'npm'
+            npmPath: 'npm',
+            limit: Math.max(require('os').cpus().length, 2)
         });
 
         var projects = this.data.projects || this.data;
@@ -89,7 +91,7 @@ module.exports = function (grunt) {
             projects = res;
         }
 
-        grunt.util.async.forEach(Object.keys(projects), function (path, next) {
+        async.eachLimit(Object.keys(projects), options.limit, function (path, next) {
             var tasks = projects[path];
             if (!(tasks instanceof Array)) {
                 tasks = [tasks];


### PR DESCRIPTION
First of all, thanks for taking the time to build this plugin, it just saved me a lot of trouble!

I've modified the script. I was running it with more than ten sub-projects (not ideal, but it's a very specific project with complex templates). Each time I rebuilt the full project with grunt-subgrunt it was killing my system with only two cores and lots of processes trying to use the whole cpu. 

Merit from this code comes from [grunt-concurrent](https://github.com/sindresorhus/grunt-concurrent/)
