### PR TITLE
new option, gruntFlags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,12 @@ Default value: `'npm'`
 
 The location of the `npm` executable. Defaults to `'npm'` as it should be available in the `$PATH` environment variable.
 
+#### options.passGruntFlags
+Type: `bool`
+Default value: `true`
+
+When enabled, passes the grunt.options thru to the subgrunt task.
+
 #### options.limit
 Type: `Number`  
 Default value: Number of CPU cores (`require('os').cpus().length`) with a minimum of 2

--- a/tasks/subgrunt.js
+++ b/tasks/subgrunt.js
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
     };
 
     var runGruntTasks = function (path, tasks, options, next) {
-        var args = grunt.option.flags().concat(tasks);
+        var args = options.gruntFlags ? grunt.option.flags().concat(tasks) : tasks;
 
         grunt.util.spawn({
             grunt: true,
@@ -78,6 +78,7 @@ module.exports = function (grunt) {
             npmInstall: true,
             npmClean: false,
             npmPath: 'npm',
+            passGruntFlags: true,
             limit: Math.max(require('os').cpus().length, 2)
         });
 


### PR DESCRIPTION
I needed a way to stop grunt.options bleeding into the subgrunt's grunt execution. I didn't see a way to prevent this without making a minor modification to your library that gives an option to allow this behavior or not.
