### PR TITLE
Allow optional passing of command args to npm install and prune

### DIFF
--- a/tasks/subgrunt.js
+++ b/tasks/subgrunt.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
   const runNpmInstall = function (path, options, next) {
     grunt.util.spawn({
       cmd: options.npmPath,
-      args: ['install'],
+      args: options.npmInstallArgs,
       opts: {cwd: path, stdio: 'inherit'}
     }, (err, result, code) => {
       if (err || code > 0) {
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 
     grunt.util.spawn({
       cmd: options.npmPath,
-      args: ['prune', '--production'],
+      args: options.npmCleanArgs,
       opts: {cwd: path, stdio: 'inherit'}
     }, (err, result, code) => {
       if (err || code > 0) {
@@ -71,6 +71,8 @@ module.exports = function (grunt) {
       npmInstall: true,
       npmClean: false,
       npmPath: 'npm',
+      npmInstallArgs: ['install'],
+      npmCleanArgs: ['prune', '--production'],
       passGruntFlags: true,
       limit: Math.max(require('os').cpus().length, 2)
     })


### PR DESCRIPTION
+ Install command allows passing args with present value being the default
+ Clean command allows passing custom args with present value being the default

Resolves #83